### PR TITLE
Perform stream validation

### DIFF
--- a/core/src/swam/binary/ModuleParser.scala
+++ b/core/src/swam/binary/ModuleParser.scala
@@ -39,117 +39,45 @@ class SwamParser[F[_]](implicit F: Sync[F]) {
     */
   def parse(stream: Stream[F, Section], validator: Validator[F] = new SpecValidator[F]): F[Module] =
     stream
-    // compile the section stream
-    .compile
-    // accept sections in order
-      .fold(F.pure((0, Vector.empty[TypeIdx], EmptyModule, EmptyContext[F]))) { (acc, sec) =>
-        acc.flatMap {
-          case (idx, tpes, mod, ctx) =>
-            if (sec.id > 0 && sec.id <= idx)
-              F.raiseError(
-                new BinaryException(s"${nameOf(sec.id)} section may not appear after ${nameOf(idx)} section")
-              )
-            else
-              sec match {
-                case Section.Types(functypes) =>
-                  for (_ <- validator.validateAll(functypes, validator.validateFuncType))
-                    yield (sec.id, tpes, mod.copy(types = functypes), ctx.copy(types = functypes))
-                case Section.Imports(imports) =>
-                  for (_ <- validator.validateAll(imports, ctx, validator.validateImport))
-                    yield {
-                      val mod1 = mod.copy(imports = imports)
-                      val ctx1 = ctx.copy[F](funcs = mod1.imported.funcs,
-                                             tables = mod1.imported.tables,
-                                             mems = mod1.imported.mems,
-                                             globals = mod1.imported.globals)
-                      (sec.id, tpes, mod1, ctx1)
-                    }
-                case Section.Functions(tpes) =>
-                  F.pure {
-                    val funcs = tpes.map(mod.types(_))
-                    (sec.id, tpes, mod, ctx.copy(funcs = ctx.funcs ++ funcs))
-                  }
-                case Section.Tables(tables) =>
-                  if (tables.size > 1)
-                    F.raiseError(new ValidationException("at most one table is allowed."))
-                  else
-                    for (_ <- validator.validateAll(tables, validator.validateTableType))
-                      yield (sec.id, tpes, mod.copy(tables = tables), ctx.copy(tables = ctx.tables ++ tables))
-                case Section.Memories(mems) =>
-                  if (mems.size > 1)
-                    F.raiseError(new ValidationException("at most one memory is allowed."))
-                  else
-                    for (_ <- validator.validateAll(mems, validator.validateMemType))
-                      yield (sec.id, tpes, mod.copy(mems = mems), ctx.copy(mems = ctx.mems ++ mems))
-                case Section.Globals(globals) =>
-                  for (_ <- validator.validateAll(globals,
-                                                  EmptyContext[F].copy(globals = mod.imported.globals),
-                                                  validator.validateGlobal))
-                    yield
-                      (sec.id, tpes, mod.copy(globals = globals), ctx.copy(globals = ctx.globals ++ globals.map(_.tpe)))
-                case Section.Exports(exports) =>
-                  val duplicate = exports
-                    .groupBy(_.fieldName)
-                    .mapValues(_.size)
-                    .find(_._2 > 1)
-                  duplicate match {
-                    case Some((name, _)) =>
-                      F.raiseError(new ValidationException(s"duplicate export name $name."))
-                    case None =>
-                      for (_ <- validator.validateAll(exports, ctx, validator.validateExport))
-                        yield (sec.id, tpes, mod.copy(exports = exports), ctx)
-                  }
-                case Section.Start(start) =>
-                  for (_ <- validator.validateStart(start, ctx))
-                    yield (sec.id, tpes, mod.copy(start = Some(start)), ctx)
-                case Section.Elements(elem) =>
-                  for (_ <- validator.validateAll(elem, ctx, validator.validateElem))
-                    yield (sec.id, tpes, mod.copy(elem = elem), ctx)
-                case Section.Code(code) =>
-                  if (code.size != tpes.size)
-                    F.raiseError(
-                      new BinaryException("code and function sections must have the same number of elements")
-                    )
-                  else {
-                    val funcs = code.zip(tpes).map {
-                      case (FuncBody(locals, code), typeIdx) =>
-                        val locs = locals.flatMap {
-                          case LocalEntry(count, tpe) =>
-                            Vector.fill(count)(tpe)
-                        }
-                        Func(typeIdx, locs, code)
-                    }
-                    for (_ <- validator.validateAll(funcs, ctx, validator.validateFunction))
-                      yield (sec.id, Vector.empty, mod.copy(funcs = funcs), ctx)
-                  }
-                case Section.Datas(data) =>
-                  for (_ <- validator.validateAll(data, ctx, validator.validateData))
-                    yield (sec.id, tpes, mod.copy(data = data), ctx)
-                case Section.Custom(_, _) =>
-                  // ignore the custom sections
-                  F.pure((idx, tpes, mod, ctx))
-              }
+      .through(validator.validate)
+      // compile the section stream
+      .compile
+      // accept sections in order
+      .fold(EmptyModule) { (mod, sec) =>
+        sec match {
+          case Section.Types(functypes) =>
+            mod.copy(types = functypes)
+          case Section.Imports(imports) =>
+            mod.copy(imports = imports)
+          case Section.Functions(tpes) =>
+            mod
+          case Section.Tables(tables) =>
+            mod.copy(tables = tables)
+          case Section.Memories(mems) =>
+            mod.copy(mems = mems)
+          case Section.Globals(globals) =>
+            mod.copy(globals = globals)
+          case Section.Exports(exports) =>
+            mod.copy(exports = exports)
+          case Section.Start(start) =>
+            mod.copy(start = Some(start))
+          case Section.Elements(elem) =>
+            mod.copy(elem = elem)
+          case Section.Code(code) =>
+            val funcs = code.zip(mod.funcs.indices).map {
+              case (FuncBody(locals, code), typeIdx) =>
+                val locs = locals.flatMap {
+                  case LocalEntry(count, tpe) =>
+                    Vector.fill(count)(tpe)
+                }
+                Func(typeIdx, locs, code)
+            }
+            mod.copy(funcs = funcs)
+          case Section.Datas(data) =>
+            mod.copy(data = data)
+          case Section.Custom(_, _) =>
+            // ignore the custom sections
+            mod
         }
       }
-      .flatten
-      // drop the section index and type indexes, just to keep the compiled module
-      .map(_._3)
-
-  private def nameOf(id: Int) =
-    id match {
-      case 0  => "custom"
-      case 1  => "type"
-      case 2  => "import"
-      case 3  => "function"
-      case 4  => "table"
-      case 5  => "memory"
-      case 6  => "global"
-      case 7  => "export"
-      case 8  => "start"
-      case 9  => "element"
-      case 10 => "code"
-      case 11 => "data"
-      case _  => "unknown"
-    }
-
 }

--- a/core/src/swam/validation/NoopValidator.scala
+++ b/core/src/swam/validation/NoopValidator.scala
@@ -21,31 +21,10 @@ import syntax._
 
 import cats._
 
+import fs2._
+
 import scala.language.higherKinds
 
 class NoopValidator[F[_]](implicit F: MonadError[F, Throwable]) extends Validator[F] {
-  val ok = F.pure(())
-  def validateConst(intr: Inst, ctx: Ctx): F[Unit] = ok
-  def validateConst(intr: Vector[Inst], ctx: Ctx): F[Unit] = ok
-  def validate(inst: Inst, ctx: Ctx): F[Ctx] = F.pure(ctx)
-  def validateData(data: Data, ctx: Ctx): F[Unit] = ok
-  def validateElem(elem: Elem, ctx: Ctx): F[Unit] = ok
-  def validateExport(exp: Export, ctx: Ctx): F[Unit] = ok
-  def validateFunction(tpe: Func, ctx: Ctx): F[Unit] = ok
-  def validateGlobal(global: Global, ctx: Ctx): F[Unit] = ok
-  def validateImport(imp: Import, ctx: Ctx): F[Unit] = ok
-  def validateMem(tpe: MemType, ctx: Ctx): F[Unit] = ok
-  def validateStart(start: FuncIdx, ctx: Ctx): F[Unit] = ok
-  def validateTable(tpe: TableType, ctx: Ctx): F[Unit] = ok
-  def validateElemType(tpe: ElemType): F[Unit] = ok
-  def validateExternType(tpe: ExternType): F[Unit] = ok
-  def validateFuncType(tpe: FuncType): F[Unit] = ok
-  def validateGlobalType(tpe: GlobalType): F[Unit] = ok
-  def validateLimits(limits: Limits): F[Unit] = ok
-  def validateMemType(tpe: MemType): F[Unit] = ok
-  def validateResultType(tpe: ResultType): F[Unit] = ok
-  def validateTableType(tpe: TableType): F[Unit] = ok
-  def validateValType(tpe: ValType): F[Unit] = ok
-  override def validateAll[T](elements: Vector[T], validation: T => F[Unit]): F[Unit] = ok
-  override def validateAll[T](elements: Vector[T], ctx: Ctx, validation: (T, Ctx) => F[Unit]): F[Unit] = ok
+  def validate(stream: Stream[F, Section]): Stream[F, Section] = stream
 }

--- a/core/src/swam/validation/Validator.scala
+++ b/core/src/swam/validation/Validator.scala
@@ -22,70 +22,17 @@ import syntax._
 import cats._
 import cats.implicits._
 
+import fs2._
+
 import scala.language.higherKinds
 
+/** A validator makes it possible to validate sections in a stream. */
 abstract class Validator[F[_]](implicit val F: MonadError[F, Throwable]) {
 
-  type Ctx = Context[F]
-
-  protected val Ok = F.unit
-
-  def validateAll[T](elements: Vector[T], validation: T => F[Unit]): F[Unit] =
-    F.tailRecM(0) { idx =>
-      if (idx < elements.size)
-        validation(elements(idx)).map(_ => Left(idx + 1))
-      else
-        F.pure(Right(()))
-    }
-
-  def validateAll[T](elements: Vector[T], ctx: Ctx, validation: (T, Ctx) => F[Unit]): F[Unit] =
-    F.tailRecM(0) { idx =>
-      if (idx < elements.size)
-        validation(elements(idx), ctx).map(_ => Left(idx + 1))
-      else
-        F.pure(Right(()))
-    }
-
-  def validateValType(tpe: ValType): F[Unit]
-
-  def validateResultType(tpe: ResultType): F[Unit]
-
-  def validateLimits(limits: Limits): F[Unit]
-
-  def validateMemType(tpe: MemType): F[Unit]
-
-  def validateFuncType(tpe: FuncType): F[Unit]
-
-  def validateTableType(tpe: TableType): F[Unit]
-
-  def validateElemType(tpe: ElemType): F[Unit]
-
-  def validateGlobalType(tpe: GlobalType): F[Unit]
-
-  def validateExternType(tpe: ExternType): F[Unit]
-
-  def validate(inst: Inst, ctx: Ctx): F[Ctx]
-
-  def validateFunction(tpe: Func, ctx: Ctx): F[Unit]
-
-  def validateTable(tpe: TableType, ctx: Ctx): F[Unit]
-
-  def validateMem(tpe: MemType, ctx: Ctx): F[Unit]
-
-  def validateGlobal(global: Global, ctx: Ctx): F[Unit]
-
-  def validateElem(elem: Elem, ctx: Ctx): F[Unit]
-
-  def validateData(data: Data, ctx: Ctx): F[Unit]
-
-  def validateStart(start: FuncIdx, ctx: Ctx): F[Unit]
-
-  def validateImport(imp: Import, ctx: Ctx): F[Unit]
-
-  def validateExport(exp: Export, ctx: Ctx): F[Unit]
-
-  def validateConst(intr: Vector[Inst], ctx: Ctx): F[Unit]
-
-  def validateConst(intr: Inst, ctx: Ctx): F[Unit]
+  /** Performs validation of the section stream on the fly.
+   *  The sections are returned unchanged if validation succeeds, otherwise
+   *  the stream fails.
+   */
+  def validate(stream: Stream[F, Section]): Stream[F, Section]
 
 }


### PR DESCRIPTION
Instead of mixing the validation inside the module parser, perform
streaming validation. This will make it possible to avoid constructing a
module when loading a binary module to be executed. This will make it
possible to achieve streaming compilation.