### PR TITLE
Wrap memory operations in effectful type

### DIFF
--- a/runtime/src/swam/runtime/Interface.scala
+++ b/runtime/src/swam/runtime/Interface.scala
@@ -123,79 +123,79 @@ trait Memory[F[_]] extends Interface[F, MemType] {
     * This method should never throw an exception. If growing is not possible,
     * whatever the reason, it must simply return `false`.
     */
-  def grow(by: Int): Boolean
+  def grow(by: Int): F[Boolean]
 
   /** Writes a byte at the given index in memory.
     *
     *  $boundaries
     */
-  def writeByte(idx: Int, v: Byte): Unit
+  def writeByte(idx: Int, v: Byte): F[Unit]
 
   /** Reads a byte at the given index in memory.
     *
     *  $boundaries
     */
-  def readByte(idx: Int): Byte
+  def readByte(idx: Int): F[Byte]
 
   /** Writes a short at the given index in memory.
     *
     *  $boundaries
     */
-  def writeShort(idx: Int, v: Short): Unit
+  def writeShort(idx: Int, v: Short): F[Unit]
 
   /** Reads a short at the given index in memory.
     *
     *  $boundaries
     */
-  def readShort(idx: Int): Short
+  def readShort(idx: Int): F[Short]
 
   /** Writes a integer at the given index in memory.
     *
     *  $boundaries
     */
-  def writeInt(idx: Int, v: Int): Unit
+  def writeInt(idx: Int, v: Int): F[Unit]
 
   /** Reads a integer at the given index in memory.
     *
     *  $boundaries
     */
-  def readInt(idx: Int): Int
+  def readInt(idx: Int): F[Int]
 
   /** Writes a long at the given index in memory.
     *
     *  $boundaries
     */
-  def writeLong(idx: Int, v: Long): Unit
+  def writeLong(idx: Int, v: Long): F[Unit]
 
   /** Reads a long at the given index in memory.
     *
     *  $boundaries
     */
-  def readLong(idx: Int): Long
+  def readLong(idx: Int): F[Long]
 
   /** Writes a float at the given index in memory.
     *
     *  $boundaries
     */
-  def writeFloat(idx: Int, v: Float): Unit
+  def writeFloat(idx: Int, v: Float): F[Unit]
 
   /** Reads a float at the given index in memory.
     *
     *  $boundaries
     */
-  def readFloat(idx: Int): Float
+  def readFloat(idx: Int): F[Float]
 
   /** Writes a double at the given index in memory.
     *
     *  $boundaries
     */
-  def writeDouble(idx: Int, v: Double): Unit
+  def writeDouble(idx: Int, v: Double): F[Unit]
 
   /** Reads a double at the given index in memory.
     *
     *  $boundaries
     */
-  def readDouble(idx: Int): Double
+  def readDouble(idx: Int): F[Double]
 
   /** Writes the bytes in the provided buffer at the given index in memory.
     *
@@ -204,5 +204,5 @@ trait Memory[F[_]] extends Interface[F, MemType] {
     *
     *  $boundaries
     */
-  def writeBytes(idx: Int, bytes: ByteBuffer): Unit
+  def writeBytes(idx: Int, bytes: ByteBuffer): F[Unit]
 }

--- a/runtime/src/swam/runtime/internals/instance/Instantiator.scala
+++ b/runtime/src/swam/runtime/internals/instance/Instantiator.scala
@@ -24,6 +24,7 @@ import compiler._
 import interpreter._
 
 import cats._
+import cats.effect._
 import cats.implicits._
 
 import runtime._
@@ -36,7 +37,7 @@ private[runtime] class Instantiator[F[_]](engine: SwamEngine[F]) {
   private val dataOnHeap = engine.conf.data.onHeap
   private val dataHardMax = engine.conf.data.hardMax
 
-  def instantiate(module: Module[F], imports: Imports[F])(implicit F: MonadError[F, Throwable]): F[Instance[F]] = {
+  def instantiate(module: Module[F], imports: Imports[F])(implicit F: Async[F]): F[Instance[F]] = {
     for {
       // check and order the imports
       imports <- check(module.imports, imports)
@@ -90,7 +91,7 @@ private[runtime] class Instantiator[F[_]](engine: SwamEngine[F]) {
   }
 
   private def allocate(module: Module[F], globals: Vector[GlobalInstance[F]], imports: Vector[Interface[F, Type]])(
-      implicit F: MonadError[F, Throwable]): F[Instance[F]] = {
+      implicit F: Async[F]): F[Instance[F]] = {
 
     val instance = new Instance[F](module, interpreter)
 

--- a/runtime/src/swam/runtime/internals/interpreter/high/Interpreter.scala
+++ b/runtime/src/swam/runtime/internals/interpreter/high/Interpreter.scala
@@ -789,182 +789,182 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 4 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readInt(ea)
-            frame.stack.pushInt(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readInt(ea).map { c =>
+              frame.stack.pushInt(c)
+              Left(frame)
+            }
         case OpCode.I32Load8U =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 1 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 1 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readByte(ea) & 0xff
-            frame.stack.pushInt(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readByte(ea).map { c =>
+              frame.stack.pushInt(c & 0xff)
+              Left(frame)
+            }
         case OpCode.I32Load8S =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 1 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 1 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readByte(ea)
-            frame.stack.pushInt(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readByte(ea).map { c =>
+              frame.stack.pushInt(c)
+              Left(frame)
+            }
         case OpCode.I32Load16U =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 2 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 2 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readShort(ea)
-            frame.stack.pushInt(c & 0xffff)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readShort(ea).map { c =>
+              frame.stack.pushInt(c & 0xffff)
+              Left(frame)
+            }
         case OpCode.I32Load16S =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 2 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 2 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readShort(ea)
-            frame.stack.pushInt(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readShort(ea).map { c =>
+              frame.stack.pushInt(c)
+              Left(frame)
+            }
         case OpCode.I64Load =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 8 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 8 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readLong(ea)
-            frame.stack.pushLong(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readLong(ea).map { c =>
+              frame.stack.pushLong(c)
+              Left(frame)
+            }
         case OpCode.I64Load8U =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 1 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 1 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readByte(ea)
-            frame.stack.pushLong(c & 0xffl)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readByte(ea).map { c =>
+              frame.stack.pushLong(c & 0xffl)
+              Left(frame)
+            }
         case OpCode.I64Load8S =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 1 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 1 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readByte(ea)
-            frame.stack.pushLong(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readByte(ea).map { c =>
+              frame.stack.pushLong(c)
+              Left(frame)
+            }
         case OpCode.I64Load16U =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 2 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 2 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readShort(ea)
-            frame.stack.pushLong(c & 0xffffl)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readShort(ea).map { c =>
+              frame.stack.pushLong(c & 0xffffl)
+              Left(frame)
+            }
         case OpCode.I64Load16S =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 2 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 2 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readShort(ea)
-            frame.stack.pushLong(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readShort(ea).map { c =>
+              frame.stack.pushLong(c)
+              Left(frame)
+            }
         case OpCode.I64Load32U =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 4 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readInt(ea)
-            frame.stack.pushLong(c & 0xffffffffl)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readInt(ea).map { c =>
+              frame.stack.pushLong(c & 0xffffffffl)
+              Left(frame)
+            }
         case OpCode.I64Load32S =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 4 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readInt(ea)
-            frame.stack.pushLong(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readInt(ea).map { c =>
+              frame.stack.pushLong(c)
+              Left(frame)
+            }
         case OpCode.F32Load =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 4 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readFloat(ea)
-            frame.stack.pushFloat(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readFloat(ea).map { c =>
+              frame.stack.pushFloat(c)
+              Left(frame)
+            }
         case OpCode.F64Load =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 8 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 8 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readDouble(ea)
-            frame.stack.pushDouble(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readDouble(ea).map { c =>
+              frame.stack.pushDouble(c)
+              Left(frame)
+            }
         case OpCode.I32Store =>
           val align = frame.readInt()
           val offset = frame.readInt()
@@ -975,8 +975,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
-            mem.writeInt(ea, c)
-            F.pure(Left(frame))
+            mem.writeInt(ea, c).as(Left(frame))
           }
         case OpCode.I32Store8 =>
           val align = frame.readInt()
@@ -989,8 +988,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
             val c1 = (c % (1 << 8)).toByte
-            mem.writeByte(ea, c1)
-            F.pure(Left(frame))
+            mem.writeByte(ea, c1).as(Left(frame))
           }
         case OpCode.I32Store16 =>
           val align = frame.readInt()
@@ -1003,8 +1001,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
             val c1 = (c % (1 << 16)).toShort
-            mem.writeShort(ea, c1)
-            F.pure(Left(frame))
+            mem.writeShort(ea, c1).as(Left(frame))
           }
         case OpCode.I64Store =>
           val align = frame.readInt()
@@ -1016,8 +1013,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           if (offset < 0 || ea < 0 || ea + 8 > mem.size) {
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
-            mem.writeLong(ea, c)
-            F.pure(Left(frame))
+            mem.writeLong(ea, c).as(Left(frame))
           }
         case OpCode.I64Store8 =>
           val align = frame.readInt()
@@ -1030,8 +1026,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
             val c1 = (c % (1l << 8)).toByte
-            mem.writeByte(ea, c1)
-            F.pure(Left(frame))
+            mem.writeByte(ea, c1).as(Left(frame))
           }
         case OpCode.I64Store16 =>
           val align = frame.readInt()
@@ -1044,8 +1039,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
             val c1 = (c % (1l << 16)).toShort
-            mem.writeShort(ea, c1)
-            F.pure(Left(frame))
+            mem.writeShort(ea, c1).as(Left(frame))
           }
         case OpCode.I64Store32 =>
           val align = frame.readInt()
@@ -1058,8 +1052,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
             val c1 = (c % (1l << 32)).toInt
-            mem.writeInt(ea, c1)
-            F.pure(Left(frame))
+            mem.writeInt(ea, c1).as(Left(frame))
           }
         case OpCode.F32Store =>
           val align = frame.readInt()
@@ -1071,8 +1064,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
-            mem.writeFloat(ea, c)
-            F.pure(Left(frame))
+            mem.writeFloat(ea, c).as(Left(frame))
           }
         case OpCode.F64Store =>
           val align = frame.readInt()
@@ -1084,8 +1076,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           if (offset < 0 || ea < 0 || ea + 8 > mem.size) {
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
-            mem.writeDouble(ea, c)
-            F.pure(Left(frame))
+            mem.writeDouble(ea, c).as(Left(frame))
           }
         case OpCode.MemorySize =>
           val mem = frame.instance.memories(0)
@@ -1096,12 +1087,15 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           val mem = frame.instance.memories(0)
           val sz = mem.size / pageSize
           val n = frame.stack.popInt()
-          if (mem.grow(n)) {
-            frame.stack.pushInt(sz)
-          } else {
-            frame.stack.pushInt(-1)
-          }
-          F.pure(Left(frame))
+          mem
+            .grow(n)
+            .map {
+              case true =>
+                frame.stack.pushInt(sz)
+              case false =>
+                frame.stack.pushInt(-1)
+            }
+            .as(Left(frame))
         // === control instructions ===
         case OpCode.Nop =>
           F.pure(Left(frame))

--- a/runtime/src/swam/runtime/internals/interpreter/low/Interpreter.scala
+++ b/runtime/src/swam/runtime/internals/interpreter/low/Interpreter.scala
@@ -790,182 +790,182 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 4 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readInt(ea)
-            frame.stack.pushInt(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readInt(ea).map { c =>
+              frame.stack.pushInt(c)
+              Left(frame)
+            }
         case Asm.I32Load8U =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 1 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 1 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readByte(ea) & 0xff
-            frame.stack.pushInt(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readByte(ea).map { c =>
+              frame.stack.pushInt(c & 0xff)
+              Left(frame)
+            }
         case Asm.I32Load8S =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 1 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 1 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readByte(ea)
-            frame.stack.pushInt(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readByte(ea).map { c =>
+              frame.stack.pushInt(c)
+              Left(frame)
+            }
         case Asm.I32Load16U =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 2 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 2 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readShort(ea)
-            frame.stack.pushInt(c & 0xffff)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readShort(ea).map { c =>
+              frame.stack.pushInt(c & 0xffff)
+              Left(frame)
+            }
         case Asm.I32Load16S =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 2 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 2 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readShort(ea)
-            frame.stack.pushInt(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readShort(ea).map { c =>
+              frame.stack.pushInt(c)
+              Left(frame)
+            }
         case Asm.I64Load =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 8 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 8 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readLong(ea)
-            frame.stack.pushLong(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readLong(ea).map { c =>
+              frame.stack.pushLong(c)
+              Left(frame)
+            }
         case Asm.I64Load8U =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 1 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 1 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readByte(ea)
-            frame.stack.pushLong(c & 0xffl)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readByte(ea).map { c =>
+              frame.stack.pushLong(c & 0xffl)
+              Left(frame)
+            }
         case Asm.I64Load8S =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 1 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 1 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readByte(ea)
-            frame.stack.pushLong(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readByte(ea).map { c =>
+              frame.stack.pushLong(c)
+              Left(frame)
+            }
         case Asm.I64Load16U =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 2 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 2 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readShort(ea)
-            frame.stack.pushLong(c & 0xffffl)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readShort(ea).map { c =>
+              frame.stack.pushLong(c & 0xffffl)
+              Left(frame)
+            }
         case Asm.I64Load16S =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 2 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 2 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readShort(ea)
-            frame.stack.pushLong(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readShort(ea).map { c =>
+              frame.stack.pushLong(c)
+              Left(frame)
+            }
         case Asm.I64Load32U =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 4 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readInt(ea)
-            frame.stack.pushLong(c & 0xffffffffl)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readInt(ea).map { c =>
+              frame.stack.pushLong(c & 0xffffffffl)
+              Left(frame)
+            }
         case Asm.I64Load32S =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 4 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readInt(ea)
-            frame.stack.pushLong(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readInt(ea).map { c =>
+              frame.stack.pushLong(c)
+              Left(frame)
+            }
         case Asm.F32Load =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 4 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readFloat(ea)
-            frame.stack.pushFloat(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readFloat(ea).map { c =>
+              frame.stack.pushFloat(c)
+              Left(frame)
+            }
         case Asm.F64Load =>
           val align = frame.readInt()
           val offset = frame.readInt()
           val mem = frame.instance.memories(0)
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 8 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 8 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            val c = mem.readDouble(ea)
-            frame.stack.pushDouble(c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.readDouble(ea).map { c =>
+              frame.stack.pushDouble(c)
+              Left(frame)
+            }
         case Asm.I32Store =>
           val align = frame.readInt()
           val offset = frame.readInt()
@@ -973,12 +973,10 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           val c = frame.stack.popInt()
           val i = frame.stack.popInt()
           val ea = i + offset
-          if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
+          if (offset < 0 || ea < 0 || ea + 4 > mem.size)
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
-          } else {
-            mem.writeInt(ea, c)
-            F.pure(Left(frame))
-          }
+          else
+            mem.writeInt(ea, c).as(Left(frame))
         case Asm.I32Store8 =>
           val align = frame.readInt()
           val offset = frame.readInt()
@@ -990,8 +988,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
             val c1 = (c % (1 << 8)).toByte
-            mem.writeByte(ea, c1)
-            F.pure(Left(frame))
+            mem.writeByte(ea, c1).as(Left(frame))
           }
         case Asm.I32Store16 =>
           val align = frame.readInt()
@@ -1004,8 +1001,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
             val c1 = (c % (1 << 16)).toShort
-            mem.writeShort(ea, c1)
-            F.pure(Left(frame))
+            mem.writeShort(ea, c1).as(Left(frame))
           }
         case Asm.I64Store =>
           val align = frame.readInt()
@@ -1017,8 +1013,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           if (offset < 0 || ea < 0 || ea + 8 > mem.size) {
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
-            mem.writeLong(ea, c)
-            F.pure(Left(frame))
+            mem.writeLong(ea, c).as(Left(frame))
           }
         case Asm.I64Store8 =>
           val align = frame.readInt()
@@ -1031,8 +1026,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
             val c1 = (c % (1l << 8)).toByte
-            mem.writeByte(ea, c1)
-            F.pure(Left(frame))
+            mem.writeByte(ea, c1).as(Left(frame))
           }
         case Asm.I64Store16 =>
           val align = frame.readInt()
@@ -1045,8 +1039,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
             val c1 = (c % (1l << 16)).toShort
-            mem.writeShort(ea, c1)
-            F.pure(Left(frame))
+            mem.writeShort(ea, c1).as(Left(frame))
           }
         case Asm.I64Store32 =>
           val align = frame.readInt()
@@ -1059,8 +1052,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
             val c1 = (c % (1l << 32)).toInt
-            mem.writeInt(ea, c1)
-            F.pure(Left(frame))
+            mem.writeInt(ea, c1).as(Left(frame))
           }
         case Asm.F32Store =>
           val align = frame.readInt()
@@ -1072,8 +1064,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           if (offset < 0 || ea < 0 || ea + 4 > mem.size) {
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
-            mem.writeFloat(ea, c)
-            F.pure(Left(frame))
+            mem.writeFloat(ea, c).as(Left(frame))
           }
         case Asm.F64Store =>
           val align = frame.readInt()
@@ -1085,8 +1076,7 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           if (offset < 0 || ea < 0 || ea + 8 > mem.size) {
             F.raiseError(new TrapException(frame, "out of bounds memory access"))
           } else {
-            mem.writeDouble(ea, c)
-            F.pure(Left(frame))
+            mem.writeDouble(ea, c).as(Left(frame))
           }
         case Asm.MemorySize =>
           val mem = frame.instance.memories(0)
@@ -1097,12 +1087,13 @@ private[runtime] class Interpreter[F[_]](engine: SwamEngine[F]) extends interpre
           val mem = frame.instance.memories(0)
           val sz = mem.size / pageSize
           val n = frame.stack.popInt()
-          if (mem.grow(n)) {
-            frame.stack.pushInt(sz)
-          } else {
-            frame.stack.pushInt(-1)
-          }
-          F.pure(Left(frame))
+          mem
+            .grow(n)
+            .map {
+              case true  => frame.stack.pushInt(sz)
+              case flase => frame.stack.pushInt(-1)
+            }
+            .as(Left(frame))
         // === control instructions ===
         case Asm.Nop =>
           F.pure(Left(frame))


### PR DESCRIPTION
Potentially any memory read/write might fail due to some system problem,
Make the implementation safer by wrapping everything in an effectful
type.