### PR TITLE
Bump dependency versions

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.0.0-RC7"
+version = "2.0.0"
 maxColumn = 120
 danglingParentheses = false
 align.openParenCallSite = true

--- a/benchmarks/src/swam/runtime/internals/interpreter/StackPerformances.scala
+++ b/benchmarks/src/swam/runtime/internals/interpreter/StackPerformances.scala
@@ -23,7 +23,6 @@ package high
 import org.openjdk.jmh.infra._
 import org.openjdk.jmh.annotations._
 
-import cats._
 import cats.implicits._
 
 import scala.util.Random

--- a/build.sc
+++ b/build.sc
@@ -30,11 +30,13 @@ val swamUrl = "https://github.com/satabin/swam"
 
 val swamDeveloper = Developer("satabin", "Lucas Satabin", "https://github.com/satabin")
 
-val pureconfigVersion = "0.11.1"
+val fs2Version = "2.0.1"
+
+val pureconfigVersion = "0.12.1"
 
 trait SwamModule extends ScalaModule with ScalafmtModule with Headers {
 
-  def scalaVersion = "2.12.8"
+  def scalaVersion = "2.12.10"
 
   def scalacOptions =
     Seq("-feature", "-deprecation", "-unchecked", "-Ypartial-unification", "-Ypatmat-exhaust-depth", "off", "-Ywarn-unused:locals,imports")
@@ -48,7 +50,7 @@ trait SwamModule extends ScalaModule with ScalafmtModule with Headers {
 
 trait ScoverageSwamModule extends SwamModule with ScoverageModule {
 
-  def scoverageVersion = "1.3.1"
+  def scoverageVersion = "1.4.0"
 
 }
 
@@ -57,8 +59,9 @@ object core extends SwamModule with PublishModule {
   def ivyDeps =
     Agg(
       ivy"com.beachape::enumeratum:1.5.13",
-      ivy"co.fs2::fs2-core:1.1.0-M2",
-      ivy"org.scodec::scodec-stream:1.2.1",
+      ivy"co.fs2::fs2-core:$fs2Version",
+      ivy"co.fs2::fs2-io:$fs2Version",
+      ivy"org.scodec::scodec-stream:2.0.0",
       ivy"com.github.pureconfig::pureconfig-generic:$pureconfigVersion",
       ivy"com.github.pureconfig::pureconfig-squants:$pureconfigVersion",
       ivy"com.github.pureconfig::pureconfig-cats-effect:$pureconfigVersion",
@@ -90,7 +93,7 @@ object core extends SwamModule with PublishModule {
 object text extends SwamModule with PublishModule {
   def moduleDeps = Seq(core)
 
-  def ivyDeps = Agg(ivy"com.lihaoyi::fastparse:2.1.3", ivy"co.fs2::fs2-io:1.1.0-M2")
+  def ivyDeps = Agg(ivy"com.lihaoyi::fastparse:2.1.3", ivy"co.fs2::fs2-io:$fs2Version")
 
   def publishVersion = swamVersion
 

--- a/core/src/swam/binary/ModuleStream.scala
+++ b/core/src/swam/binary/ModuleStream.scala
@@ -19,12 +19,7 @@ package binary
 
 import syntax._
 
-import scodec.bits._
 import scodec.stream._
-
-import scodec._
-import scodec.codecs._
-import scodec.codecs.literals._
 
 /** The module streams expose way to encode and decode WebAssembly modules in
   *  binary format.
@@ -34,22 +29,10 @@ import scodec.codecs.literals._
   */
 object ModuleStream {
 
-  private val header: Codec[Unit] =
-    ("magic" | hex"0061736d") ~>
-      ("version" | hex"01000000")
-
-  val sections: StreamCodec[Section] =
-    StreamCodec
-      .instance(encode.once(WasmCodec.section), decode.once(WasmCodec.section))
-      .many
-
   val decoder: StreamDecoder[Section] =
-    for {
-      () <- decode.once(header)
-      section <- sections
-    } yield section
+    StreamDecoder.many(WasmCodec.section)
 
   def encoder: StreamEncoder[Section] =
-    encode.emit(hex"0061736d01000000".bits) ++ sections
+    StreamEncoder.many(WasmCodec.section)
 
 }

--- a/core/src/swam/binary/WasmCodec.scala
+++ b/core/src/swam/binary/WasmCodec.scala
@@ -26,17 +26,17 @@ import scodec.codecs._
 
 object WasmCodec extends InstCodec {
 
-  protected val externalKind: Codec[ExternalKind] =
+  val externalKind: Codec[ExternalKind] =
     mappedEnum(byte,
                Map[ExternalKind, Byte](ExternalKind.Function -> 0,
                                        ExternalKind.Table -> 1,
                                        ExternalKind.Memory -> 2,
                                        ExternalKind.Global -> 3))
 
-  protected val types: Codec[Vector[FuncType]] =
+  val types: Codec[Vector[FuncType]] =
     variableSizeBytes(varuint32, vectorWithN(varuint32, funcType))
 
-  protected val importEntry: Codec[String ~ String ~ Import] =
+  val importEntry: Codec[String ~ String ~ Import] =
     (("module" | variableSizeBytes(varuint32, utf8)) ~
       ("field" | variableSizeBytes(varuint32, utf8))).flatZip {
       case (module, field) =>
@@ -50,65 +50,65 @@ object WasmCodec extends InstCodec {
           .|(ExternalKind.Global) { case Import.Global(_, _, tpe) => tpe }(Import.Global(module, field, _))(globalType)
     }
 
-  protected val imports: Codec[Vector[Import]] =
+  val imports: Codec[Vector[Import]] =
     variableSizeBytes(varuint32, vectorWithN(varuint32, importEntry.xmap({
       case (_, e)                  => e
     }, { case e @ Import(mod, fld) => ((mod, fld), e) })))
 
-  protected val functions: Codec[Vector[Int]] =
+  val functions: Codec[Vector[Int]] =
     variableSizeBytes(varuint32, vectorWithN(varuint32, varuint32))
 
-  protected val tables: Codec[Vector[TableType]] =
+  val tables: Codec[Vector[TableType]] =
     variableSizeBytes(varuint32, vectorWithN(varuint32, tableType))
 
-  protected val mems: Codec[Vector[MemType]] =
+  val mems: Codec[Vector[MemType]] =
     variableSizeBytes(varuint32, vectorWithN(varuint32, memoryType))
 
-  protected val globalVariable: Codec[Global] =
+  val globalVariable: Codec[Global] =
     (globalType :: expr).as[Global]
 
-  protected val globals: Codec[Vector[Global]] =
+  val globals: Codec[Vector[Global]] =
     variableSizeBytes(varuint32, vectorWithN(varuint32, globalVariable))
 
-  protected val elemSegment: Codec[Elem] =
+  val elemSegment: Codec[Elem] =
     (("index" | varuint32) ::
       ("offset" | expr) ::
       ("elems" | vectorOfN(varuint32, varuint32))).as[Elem]
 
-  protected val elem: Codec[Vector[Elem]] =
+  val elem: Codec[Vector[Elem]] =
     variableSizeBytes(varuint32, vectorWithN(varuint32, elemSegment))
 
-  protected val dataSegment: Codec[Data] =
+  val dataSegment: Codec[Data] =
     (("index" | varuint32) ::
       ("offset" | expr) ::
       ("data" | variableSizeBytes(varuint32, scodec.codecs.bits))).as[Data]
 
-  protected val data: Codec[Vector[Data]] =
+  val data: Codec[Vector[Data]] =
     variableSizeBytes(varuint32, vectorWithN(varuint32, dataSegment))
 
-  protected val start: Codec[FuncIdx] =
+  val start: Codec[FuncIdx] =
     variableSizeBytes(varuint32, varuint32)
 
-  protected val localEntry: Codec[LocalEntry] =
+  val localEntry: Codec[LocalEntry] =
     (varuint32 :: valType).as[LocalEntry]
 
-  protected val funcBody: Codec[FuncBody] =
+  val funcBody: Codec[FuncBody] =
     variableSizeBytes(varuint32,
                       (("locals" | vectorOfN(varuint32, localEntry)) ::
                         ("code" | expr)).as[FuncBody])
 
-  protected val code: Codec[Vector[FuncBody]] =
+  val code: Codec[Vector[FuncBody]] =
     variableSizeBytes(varuint32, vectorWithN(varuint32, funcBody))
 
-  protected val exportEntry: Codec[Export] =
+  val exportEntry: Codec[Export] =
     (("field" | variableSizeBytes(varuint32, utf8)) ::
       ("kind" | externalKind) ::
       ("index" | varuint32)).as[Export]
 
-  protected val exports: Codec[Vector[Export]] =
+  val exports: Codec[Vector[Export]] =
     variableSizeBytes(varuint32, vectorWithN(varuint32, exportEntry))
 
-  protected val custom: Codec[(String, BitVector)] =
+  val custom: Codec[(String, BitVector)] =
     variableSizeBytes(varuint32,
                       (("name" | variableSizeBytes(varuint32, utf8)) ~
                         ("payload" | scodec.codecs.bits)))

--- a/core/src/swam/binary/package.scala
+++ b/core/src/swam/binary/package.scala
@@ -16,6 +16,8 @@
 
 package swam
 
+import fs2._
+
 import scodec.bits._
 import scodec._
 import scodec.codecs._
@@ -24,7 +26,11 @@ import scala.annotation.tailrec
 
 import scala.collection.immutable.VectorBuilder
 
+import scala.language.higherKinds
+
 package object binary {
+
+  type VarResut[F[_]] = (Long, Option[(ByteVector, Int, Stream[F, Byte])])
 
   val noop: Codec[Unit] = new Codec[Unit] {
     def decode(bits: BitVector): Attempt[DecodeResult[Unit]] =

--- a/core/src/swam/decompilation/Decompiler.scala
+++ b/core/src/swam/decompilation/Decompiler.scala
@@ -22,8 +22,6 @@ import util.pretty.Doc
 
 import cats.effect._
 
-import scodec.bits._
-
 import fs2._
 
 import java.nio.file.Path
@@ -40,15 +38,15 @@ abstract class Decompiler[F[_]](implicit F: Effect[F]) extends ModuleLoader[F] {
     *
     * The module is not validated so invalid modules can also be decompiled.
     */
-  def decompile(path: Path): F[Doc] =
-    decompile(readPath(path))
+  def decompilePath(path: Path, blocker: Blocker, chunkSize: Int = 1024)(implicit cs: ContextShift[F]): F[Doc] =
+    decompile(readPath(path, blocker, chunkSize))
 
   /** Returns a pretty-printed [[swam.util.pretty.Doc Doc]] resulting from decompiling
     * the module at the given bytes.
     *
     * The module is not validated so invalid modules can also be decompiled.
     */
-  def decompile(bytes: BitVector): F[Doc] =
+  def decompileBytes(bytes: Stream[F, Byte]): F[Doc] =
     decompile(readBytes(bytes))
 
   /** Returns a pretty-printed [[swam.util.pretty.Doc Doc]] resulting from decompiling

--- a/core/src/swam/opcodes.scala
+++ b/core/src/swam/opcodes.scala
@@ -196,8 +196,11 @@ object OpCode {
   final val F64ReinterpretI64 = 0xbf
 
   def withValueOpt(i: Int): Option[OpCode] =
-    if (all.contains(i))
-      Some(i)
+    unapply(i.toByte)
+
+  def unapply(b: Byte): Option[OpCode] =
+    if (all.contains(b))
+      Some(b)
     else
       None
 

--- a/core/src/swam/validation/Validator.scala
+++ b/core/src/swam/validation/Validator.scala
@@ -24,6 +24,7 @@ import cats._
 import cats.effect._
 import cats.implicits._
 
+import pureconfig._
 import pureconfig.generic.auto._
 import pureconfig.module.squants._
 import pureconfig.module.catseffect._
@@ -52,6 +53,6 @@ object Validator {
 
   def apply[F[_]: Sync]: F[Validator[F]] =
     for {
-      conf <- loadConfigF[F, ValidationConfiguration]("swam.validation")
+      conf <- ConfigSource.default.at("swam.validation").loadF[F, ValidationConfiguration]
     } yield apply[F](conf)
 }

--- a/runtime/test/src/swam/runtime/ScriptEngine.scala
+++ b/runtime/test/src/swam/runtime/ScriptEngine.scala
@@ -25,15 +25,15 @@ import imports._
 import unresolved._
 import validation._
 
-
 import cats._
 import cats.implicits._
 import cats.effect._
 
-import scodec.bits._
+import fs2._
 
 import java.lang.{Float => JFloat, Double => JDouble}
 
+import pureconfig._
 import pureconfig.generic.auto._
 import pureconfig.module.squants._
 import pureconfig.module.catseffect._
@@ -76,7 +76,7 @@ class ScriptEngine(useLowLevel: Boolean) {
   val engine =
     for {
       validator <- Validator[IO]
-      conf <- loadConfigF[IO, EngineConfiguration]("swam.runtime")
+      conf <- ConfigSource.default.at("swam.runtime").loadF[IO, EngineConfiguration]
     } yield Engine[IO](conf.copy(useLowLevelAsm = useLowLevel), validator)
 
   val tcompiler = Compiler[IO]
@@ -100,7 +100,7 @@ class ScriptEngine(useLowLevel: Boolean) {
             for {
               engine <- engine
               tcompiler <- tcompiler
-              compiled <- engine.compile(BitVector(bs))
+              compiled <- engine.compileBytes(Stream.emits(bs.toArray))
               instance <- compiled.importing(ctx.imports).instantiate
             } yield id match {
               case Some(name) =>
@@ -254,7 +254,7 @@ class ScriptEngine(useLowLevel: Boolean) {
           for {
             engine <- engine
             tcompiler <- tcompiler
-            res <- engine.compile(BitVector(bs))
+            res <- engine.compileBytes(Stream.emits(bs.toArray))
           } yield res
         case QuotedModule(_, src) =>
           for {

--- a/runtime/test/src/swam/text/SpecTests.scala
+++ b/runtime/test/src/swam/text/SpecTests.scala
@@ -17,10 +17,8 @@
 package swam
 package text
 
-import util._
 import parser._
 import runtime._
-import validation._
 
 import swam.test.util._
 


### PR DESCRIPTION
The behavior of scodec-stream changed quite a lot with the new fs2 2.0.0
version, which supports scala 2.13.

This leads to breaking changes in the API, to make it work with new
cats-effect and fs2 APIs.