### PR TITLE
Fixed broked links in .md files under swam/examples/docs

### DIFF
--- a/examples/docs/annotations.md
+++ b/examples/docs/annotations.md
@@ -87,7 +87,7 @@ class PureModule {
 val pm = new PureModule
 ```
 
-WebAssembly modules can now [import it, and call it](/examples/pure-annotations.wat):
+WebAssembly modules can now [import it, and call it](https://github.com/satabin/swam/blob/master/examples/docs/pure-annotations.wat):
 
 ```scala mdoc:silent
 val add42 = (for {
@@ -127,7 +127,7 @@ class EffectfulModule[@effect F[_]](implicit F: Applicative[F]) {
 val mIO = new EffectfulModule[IO]
 ```
 
-Now, WebAssembly modules can [import that module and use the effectful function](/examples/effectful-annotations.wat):
+Now, WebAssembly modules can [import that module and use the effectful function](https://github.com/satabin/swam/blob/master/examples/docs/effectful-annotations.wat):
 
 ```scala mdoc:silent
 val logged = (for {

--- a/examples/docs/annotations.md
+++ b/examples/docs/annotations.md
@@ -36,7 +36,7 @@ class MyModule {
 val m = new MyModule
 ```
 
-Instance `m` can be used as an [import](/examples/annotations.wat) and `v3` can be mutated from a WebAssembly module.
+Instance `m` can be used as an [import](https://github.com/shrin18/swam/blob/master/examples/docs/annotations.wat) and `v3` can be mutated from a WebAssembly module.
 
 ```scala mdoc:silent
 import swam._

--- a/examples/docs/decompiler.md
+++ b/examples/docs/decompiler.md
@@ -2,7 +2,7 @@
 title: Decompilers
 ---
 
-Decompilers make it possible to have human readyble representations of a compiled WebAssembly module. For instance, having defined [functions to compute fibonacci numbers](/examples/fibo.wat).
+Decompilers make it possible to have human readyble representations of a compiled WebAssembly module. For instance, having defined [functions to compute fibonacci numbers](https://github.com/satabin/swam/blob/master/examples/docs/fibo.wat).
 
 ```scala mdoc:silent
 import swam._

--- a/examples/docs/fibo.md
+++ b/examples/docs/fibo.md
@@ -2,7 +2,7 @@
 title: Recursion
 ---
 
-Recursive functions are allowed. For instance, having defined [functions to compute fibonacci numbers](/examples/fibo.wat).
+Recursive functions are allowed. For instance, having defined [functions to compute fibonacci numbers](https://github.com/satabin/swam/blob/master/examples/docs/fibo.wat).
 
 ```scala mdoc:silent
 import swam._

--- a/examples/docs/logged.md
+++ b/examples/docs/logged.md
@@ -2,7 +2,7 @@
 title: Imports
 ---
 
-When a module is instantiated, it is possible to import functions or values from Scala into the module. For instance, let’s assume we defined a function that prints its parameter on the console, and a [simple WebAssembly module that imports and calls it](/examples/logged.wat).
+When a module is instantiated, it is possible to import functions or values from Scala into the module. For instance, let’s assume we defined a function that prints its parameter on the console, and a [simple WebAssembly module that imports and calls it](https://github.com/satabin/swam/blob/master/examples/docs/logged.wat).
 
 ```scala mdoc:silent
 import swam._

--- a/examples/docs/string.md
+++ b/examples/docs/string.md
@@ -2,7 +2,7 @@
 title: Strings
 ---
 
-WebAssembly only has value integer types. However, providing a correct reader, one can interpret an integer as the address of a complex object in memory and convert it back to scala when exported. By default, Swam provides such readers for strings, either C-like or UTF-8 encoded strings. Let’s assume we have [a WebAssembly module that exports two strings](/examples/string.wat)
+WebAssembly only has value integer types. However, providing a correct reader, one can interpret an integer as the address of a complex object in memory and convert it back to scala when exported. By default, Swam provides such readers for strings, either C-like or UTF-8 encoded strings. Let’s assume we have [a WebAssembly module that exports two strings](https://github.com/satabin/swam/blob/master/examples/docs/string.wat)
 
 ```scala mdoc:silent
 import swam._


### PR DESCRIPTION
Hello,
Since I have started to experiment with SWAM for running several benchmarks for Web-Assembly, I thought it would be a good idea to fix the broken links in the README. I would also like to add several content for WebAssembly modules in the future.

Thanks,
Shrinish Donde