### PR TITLE
Adding log entry separator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ site/output
 
 .metals/
 .bloop/
+
+
+log.txt
+*.lck

--- a/build.sc
+++ b/build.sc
@@ -130,6 +130,10 @@ object runtime extends SwamModule with PublishModule {
 
     def testFrameworks = Seq("swam.util.Framework")
 
+    object trace extends Tests with ScalafmtModule {
+      def moduleDeps = super.moduleDeps ++ Seq(runtime.test)
+      def testFrameworks = Seq("swam.util.Framework")
+    }
   }
 
 }

--- a/runtime/src/swam/runtime/trace/JULTracer.scala
+++ b/runtime/src/swam/runtime/trace/JULTracer.scala
@@ -50,8 +50,8 @@ class JULTracer(conf: TraceConfiguration) extends Tracer {
   logger.addHandler(handler)
 
   def traceEvent(tpe: EventType, args: List[String]): Unit =
-    if (tpe.entryName.matches(conf.filter))
-      logger.info(s"${tpe.entryName},${args.mkString(",")}")
+    if (conf.filter.equals("*") || tpe.entryName.matches(conf.filter))
+      logger.info(s"${tpe.entryName},${args.mkString(",")}${conf.separator}")
 
 }
 
@@ -63,6 +63,7 @@ private object PureFormatter extends Formatter {
 }
 
 case class TraceConfiguration(handler: HandlerType,
+                              separator: String,
                               filter: String,
                               level: String,
                               fileHandler: TracerFileHandlerCondiguration,

--- a/runtime/test/src/trace/TraceTests.scala
+++ b/runtime/test/src/trace/TraceTests.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Lucas Satabin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package swam
+package runtime
+package trace
+
+
+import utest._
+
+object TracerTests extends TestSuite {
+
+
+  def runLog(handler: HandlerType) = {
+    val conf: TraceConfiguration = new TraceConfiguration(
+        handler,
+        "\n",
+        "*",
+        "ALL",
+        new TracerFileHandlerCondiguration(
+          "log.txt",
+          true,
+          "."
+        ),
+        new SocketHanndlerCondiguration("localhost", 8080),
+        new CustomTracerConfiguration("unknown")
+      )
+      
+      val tracer = new JULTracer(conf)
+
+      tracer.traceEvent(EventType.SPush, List("123", "4", "123"))
+  }
+
+  
+  val tests = Tests{
+    "console_tracer" - runLog(HandlerType.Console)
+    "file_tracer" - runLog(HandlerType.File)
+    // "socket_tracer" - runLog(HandlerType.Socket)
+  }
+  
+}

--- a/runtime/test/src/trace/TraceTests.scala
+++ b/runtime/test/src/trace/TraceTests.scala
@@ -18,37 +18,34 @@ package swam
 package runtime
 package trace
 
-
 import utest._
 
 object TracerTests extends TestSuite {
 
-
   def runLog(handler: HandlerType) = {
     val conf: TraceConfiguration = new TraceConfiguration(
-        handler,
-        "\n",
-        "*",
-        "ALL",
-        new TracerFileHandlerCondiguration(
-          "log.txt",
-          true,
-          "."
-        ),
-        new SocketHanndlerCondiguration("localhost", 8080),
-        new CustomTracerConfiguration("unknown")
-      )
-      
-      val tracer = new JULTracer(conf)
+      handler,
+      "\n",
+      "*",
+      "ALL",
+      new TracerFileHandlerCondiguration(
+        "log.txt",
+        true,
+        "."
+      ),
+      new SocketHanndlerCondiguration("localhost", 8080),
+      new CustomTracerConfiguration("unknown")
+    )
 
-      tracer.traceEvent(EventType.SPush, List("123", "4", "123"))
+    val tracer = new JULTracer(conf)
+
+    tracer.traceEvent(EventType.SPush, List("123", "4", "123"))
   }
 
-  
-  val tests = Tests{
+  val tests = Tests {
     "console_tracer" - runLog(HandlerType.Console)
     "file_tracer" - runLog(HandlerType.File)
     // "socket_tracer" - runLog(HandlerType.Socket)
   }
-  
+
 }


### PR DESCRIPTION
- Added tracer test script (```mill runtime.test.trace```)
- Added log entry separator in config class