### PR TITLE
Add function data to `StackFrame`s

### DIFF
--- a/runtime/src/swam/runtime/Module.scala
+++ b/runtime/src/swam/runtime/Module.scala
@@ -50,7 +50,7 @@ class Module[F[_]] private[runtime] (
     private[runtime] val data: Vector[CompiledData[F]])(implicit F: MonadError[F, Throwable]) {
   self =>
 
-  private lazy val names = {
+  private[runtime] lazy val names = {
     val sec = customs.collectFirst {
       case Custom("name", payload) => payload
     }

--- a/runtime/src/swam/runtime/StackFrame.scala
+++ b/runtime/src/swam/runtime/StackFrame.scala
@@ -20,4 +20,10 @@ package runtime
 /** Interface of a stack frame, making it possible to create
   * a call stack on trap for reporting purpose.
   */
-trait StackFrame {}
+trait StackFrame {
+
+  def moduleName: Option[String]
+
+  def functionName: Option[String]
+
+}

--- a/runtime/src/swam/runtime/internals/compiler/CompiledFunction.scala
+++ b/runtime/src/swam/runtime/internals/compiler/CompiledFunction.scala
@@ -21,4 +21,7 @@ package compiler
 
 import swam.runtime.internals.interpreter.AsmInst
 
-private[runtime] case class CompiledFunction[F[_]](tpe: FuncType, locals: Vector[ValType], code: Array[AsmInst[F]])
+private[runtime] case class CompiledFunction[F[_]](idx: Int,
+                                                   tpe: FuncType,
+                                                   locals: Vector[ValType],
+                                                   code: Array[AsmInst[F]])

--- a/runtime/src/swam/runtime/internals/compiler/Compiler.scala
+++ b/runtime/src/swam/runtime/internals/compiler/Compiler.scala
@@ -178,7 +178,7 @@ class Compiler[F[_]](engine: Engine[F], asm: Asm[F])(implicit F: MonadError[F, T
                                        ctx.functions,
                                        ctx.types)._1
                 val clocals = locals.flatMap(e => Vector.fill(e.count)(e.tpe))
-                compiler.Func.Compiled(CompiledFunction(tpe, clocals, compiled))
+                compiler.Func.Compiled(CompiledFunction(idx + shift, tpe, clocals, compiled))
             }
           ctx.copy(code = code)
         case (ctx, Section.Elements(elems)) =>

--- a/runtime/src/swam/runtime/internals/instance/FunctionInstance.scala
+++ b/runtime/src/swam/runtime/internals/instance/FunctionInstance.scala
@@ -27,7 +27,8 @@ import cats.implicits._
 private[runtime] case class FunctionInstance[F[_]](tpe: FuncType,
                                                    locals: Vector[ValType],
                                                    code: Array[AsmInst[F]],
-                                                   instance: Instance[F])(implicit F: MonadError[F, Throwable])
+                                                   instance: Instance[F],
+                                                   name: Option[String])(implicit F: MonadError[F, Throwable])
     extends Function[F] {
 
   var next: FunctionInstance[F] = _

--- a/runtime/src/swam/runtime/internals/interpreter/Interpreter.scala
+++ b/runtime/src/swam/runtime/internals/interpreter/Interpreter.scala
@@ -70,7 +70,7 @@ private[runtime] class Interpreter[F[_]](engine: Engine[F])(implicit F: MonadErr
     // instantiate the top-level thread
     val thread = makeFrame(instance)
     // invoke the function
-    invoke(thread, new FunctionInstance(FuncType(Vector(), Vector(tpe)), Vector(), code, instance)) match {
+    invoke(thread, new FunctionInstance(FuncType(Vector(), Vector(tpe)), Vector(), code, instance, None)) match {
       case Continue     => run(thread)
       case Suspend(res) => res
       case Done(res)    => F.pure(res)
@@ -112,7 +112,7 @@ private[runtime] class Interpreter[F[_]](engine: Engine[F])(implicit F: MonadErr
 
   private def invoke(thread: Frame[F], f: Function[F]): Continuation[F] =
     f match {
-      case inst @ FunctionInstance(_, _, _, _) =>
+      case inst @ FunctionInstance(_, _, _, _, _) =>
         // parameters are on top of the stack
         thread.pushFrame(inst)
         Continue

--- a/runtime/src/swam/runtime/internals/interpreter/Stack.scala
+++ b/runtime/src/swam/runtime/internals/interpreter/Stack.scala
@@ -243,4 +243,10 @@ private[runtime] class ThreadFrame[F[_]](conf: StackConfiguration, baseInstance:
     else
       instance.instance.memories.lift(idx)
 
+  def functionName: Option[String] =
+    instance.name
+
+  def moduleName: Option[String] =
+    instance.instance.module.name
+
 }

--- a/runtime/src/swam/runtime/internals/interpreter/asm.scala
+++ b/runtime/src/swam/runtime/internals/interpreter/asm.scala
@@ -1961,7 +1961,7 @@ class Asm[F[_]](implicit F: MonadError[F, Throwable]) {
   sealed abstract class Invoking extends AsmInst[F] {
     protected def invoke(thread: Frame[F], f: Function[F]): Continuation[F] =
       f match {
-        case inst @ FunctionInstance(_, _, _, _) =>
+        case inst @ FunctionInstance(_, _, _, _, _) =>
           // parameters are on top of the stack
           thread.pushFrame(inst)
           Continue

--- a/runtime/src/swam/runtime/trace/JULTracer.scala
+++ b/runtime/src/swam/runtime/trace/JULTracer.scala
@@ -57,9 +57,11 @@ class JULTracer(conf: TraceConfiguration, formatter: Formatter = PureFormatter) 
   handler.setFormatter(formatter)
   logger.addHandler(handler)
 
+  override def filter(tpe: EventType, args: List[String], frame: StackFrame): Boolean =
+    conf.filter.equals("*") || tpe.entryName.matches(conf.filter)
+
   def traceEvent(tpe: EventType, args: List[String]): Unit =
-    if (conf.filter.equals("*") || tpe.entryName.matches(conf.filter))
-      logger.info(s"${tpe.entryName},${args.mkString(",")}${conf.separator}")
+    logger.info(s"${tpe.entryName},${args.mkString(",")}${conf.separator}")
 
 }
 

--- a/runtime/src/swam/runtime/trace/Tracer.scala
+++ b/runtime/src/swam/runtime/trace/Tracer.scala
@@ -19,8 +19,24 @@ package runtime
 package trace
 
 /** Tracers must implement this interface. */
-trait Tracer {
+abstract class Tracer {
 
+  /** Filters whether the given event type should be traced in the
+    * current [[StackFrame]] context.
+    * By default, traces all evcents. Override to implement custom filtering
+    * logic.
+    */
+  def filter(tpe: EventType, args: List[String], frame: StackFrame): Boolean =
+    true
+
+  /** Actually perform the tracing of the event.
+    * Filtering has already be done before this method is called,
+    * so it does not need to check whether the event is worth tracing.
+    */
   def traceEvent(tpe: EventType, args: List[String]): Unit
+
+  private[runtime] final def trace(tpe: EventType, args: List[String], frame: StackFrame): Unit =
+    if (filter(tpe, args, frame))
+      traceEvent(tpe, args)
 
 }

--- a/runtime/src/swam/runtime/trace/TracingFrame.scala
+++ b/runtime/src/swam/runtime/trace/TracingFrame.scala
@@ -46,114 +46,114 @@ private[runtime] class TracingFrame[F[_]](inner: Frame[F], tracer: Tracer) exten
   }
 
   def pushBool(b: Boolean): Unit = {
-    tracer.traceEvent(EventType.SPush, List("i32", if (b) "1" else "0"))
+    tracer.trace(EventType.SPush, List("i32", if (b) "1" else "0"), this)
     inner.pushBool(b)
   }
 
   def pushInt(i: Int): Unit = {
-    tracer.traceEvent(EventType.SPush, List("i32", i.toString))
+    tracer.trace(EventType.SPush, List("i32", i.toString), this)
     inner.pushInt(i)
   }
 
   def pushLong(l: Long): Unit = {
-    tracer.traceEvent(EventType.SPush, List("i64", l.toString))
+    tracer.trace(EventType.SPush, List("i64", l.toString), this)
     inner.pushLong(l)
   }
 
   def pushFloat(f: Float): Unit = {
-    tracer.traceEvent(EventType.SPush, List("f32", f.toString))
+    tracer.trace(EventType.SPush, List("f32", f.toString), this)
     inner.pushFloat(f)
   }
 
   def pushDouble(d: Double): Unit = {
-    tracer.traceEvent(EventType.SPush, List("f64", d.toString))
+    tracer.trace(EventType.SPush, List("f64", d.toString), this)
     inner.pushDouble(d)
   }
 
   def popBool(): Boolean = {
     val res = inner.popBool()
-    tracer.traceEvent(EventType.SPop, List("i32", if (res) "1" else "0"))
+    tracer.trace(EventType.SPop, List("i32", if (res) "1" else "0"), this)
     res
   }
 
   def popInt(): Int = {
     val res = inner.popInt()
-    tracer.traceEvent(EventType.SPop, List("i32", res.toString))
+    tracer.trace(EventType.SPop, List("i32", res.toString), this)
     res
   }
 
   def peekInt(): Int = {
     val res = inner.peekInt()
-    tracer.traceEvent(EventType.SPeek, List("i32", res.toString))
+    tracer.trace(EventType.SPeek, List("i32", res.toString), this)
     res
   }
 
   def popLong(): Long = {
     val res = inner.popLong()
-    tracer.traceEvent(EventType.SPop, List("i64", res.toString))
+    tracer.trace(EventType.SPop, List("i64", res.toString), this)
     res
   }
 
   def peekLong(): Long = {
     val res = inner.peekLong()
-    tracer.traceEvent(EventType.SPeek, List("i64", res.toString))
+    tracer.trace(EventType.SPeek, List("i64", res.toString), this)
     res
   }
 
   def popFloat(): Float = {
     val res = inner.popFloat()
-    tracer.traceEvent(EventType.SPop, List("f32", res.toString))
+    tracer.trace(EventType.SPop, List("f32", res.toString), this)
     res
   }
 
   def peekFloat(): Float = {
     val res = inner.peekFloat()
-    tracer.traceEvent(EventType.SPeek, List("f32", res.toString))
+    tracer.trace(EventType.SPeek, List("f32", res.toString), this)
     res
   }
 
   def popDouble(): Double = {
     val res = inner.popDouble()
-    tracer.traceEvent(EventType.SPop, List("f64", res.toString))
+    tracer.trace(EventType.SPop, List("f64", res.toString), this)
     res
   }
 
   def peekDouble(): Double = {
     val res = inner.peekDouble()
-    tracer.traceEvent(EventType.SPeek, List("f64", res.toString))
+    tracer.trace(EventType.SPeek, List("f64", res.toString), this)
     res
   }
 
   def drop(n: Int): Unit = {
-    tracer.traceEvent(EventType.SPop, List("i64", "drop", n.toString))
+    tracer.trace(EventType.SPop, List("i64", "drop", n.toString), this)
     inner.drop(n)
   }
 
   def popValue(): Long = {
     val res = inner.popValue()
-    tracer.traceEvent(EventType.SPop, List("i64", res.toString))
+    tracer.trace(EventType.SPop, List("i64", res.toString), this)
     res
   }
 
   def peekValue(): Long = {
     val res = inner.peekValue()
-    tracer.traceEvent(EventType.SPeek, List("i64", res.toString))
+    tracer.trace(EventType.SPeek, List("i64", res.toString), this)
     res
   }
 
   def popValues(n: Int): Seq[Long] = {
     val res = inner.popValues(n)
-    tracer.traceEvent(EventType.SPop, "i64" :: res.map(_.toString).toList)
+    tracer.trace(EventType.SPop, "i64" :: res.map(_.toString).toList, this)
     res
   }
 
   def pushValue(l: Long): Unit = {
-    tracer.traceEvent(EventType.SPush, List("i64", l.toString))
+    tracer.trace(EventType.SPush, List("i64", l.toString), this)
     inner.pushValue(l)
   }
 
   def pushValues(values: Seq[Long]): Unit = {
-    tracer.traceEvent(EventType.SPush, "i64" :: values.map(_.toString).toList)
+    tracer.trace(EventType.SPush, "i64" :: values.map(_.toString).toList, this)
     inner.pushValues(values)
   }
 
@@ -186,5 +186,11 @@ private[runtime] class TracingFrame[F[_]](inner: Frame[F], tracer: Tracer) exten
 
   def memoryOpt(idx: Int): Option[Memory[F]] =
     inner.memoryOpt(idx)
+
+  def functionName: Option[String] =
+    inner.functionName
+
+  def moduleName: Option[String] =
+    inner.moduleName
 
 }


### PR DESCRIPTION
In case a custom name section is available in a wasm module, use it to
push the function name onto the stack. The potential module and function
names can be accessed for the current stack to implement several
features:
 - can help debugging by getting the context in which a problem occurs
 - can help filtering events to trace or not based on calling context

fix #75