### PR TITLE
Fix loop validation with return type

### DIFF
--- a/core/src/swam/syntax/pretty/package.scala
+++ b/core/src/swam/syntax/pretty/package.scala
@@ -250,10 +250,10 @@ package object pretty {
         case Unreachable => str("unreachable")
 
         case Block(tpe, is) =>
-          group(str("block") ++ space ++ tpe.pretty ++ nest(2, group(line ++ seq(line, is)) ++ line ++ str("end")))
+          group(str("block") ++ space ++ tpe.pretty ++ nest(2, group(line ++ seq(line, is))) ++ line ++ str("end"))
 
         case Loop(tpe, is) =>
-          group(str("loop") ++ space ++ tpe.pretty ++ nest(2, group(line ++ seq(line, is)) ++ line ++ str("end")))
+          group(str("loop") ++ space ++ tpe.pretty ++ nest(2, group(line ++ seq(line, is))) ++ line ++ str("end"))
 
         case If(tpe, t, e) =>
           group(

--- a/core/src/swam/validation/Context.scala
+++ b/core/src/swam/validation/Context.scala
@@ -119,7 +119,7 @@ case class Context[F[_]](types: Vector[FuncType],
   private def extractType(bt: BlockType, loop: Boolean): F[(Vector[ValType], Int)] =
     bt match {
       case BlockType.NoType         => F.pure((Vector.empty, 0))
-      case BlockType.ValueType(tpe) => F.pure((Vector(tpe), 0))
+      case BlockType.ValueType(tpe) => F.pure((if (loop) Vector.empty else Vector(tpe), 0))
       case BlockType.FunctionType(tpeIdx) =>
         types.lift(tpeIdx) match {
           case Some(FuncType(params, results)) =>


### PR DESCRIPTION
When entering a loop context, breaks need values from loop parameter
types. In case the type of the loop is a simple type, this type is the
return type, and the loop takes no parameters on break.

Closes #82