### PR TITLE
Make decoder work better in a streaming context

### DIFF
--- a/cli/src/swam/cli/options.scala
+++ b/cli/src/swam/cli/options.scala
@@ -34,11 +34,12 @@ case class Run(file: Path,
                traceFilter: String,
                traceFile: Path,
                dirs: List[Path],
-               debug: Boolean)
+               debug: Boolean,
+               readChunkSize: Int)
     extends Options
 
-case class Decompile(file: Path, textual: Boolean, out: Option[Path]) extends Options
+case class Decompile(file: Path, textual: Boolean, out: Option[Path], readChunkSize: Int) extends Options
 
-case class Validate(file: Path, wat: Boolean, dev: Boolean) extends Options
+case class Validate(file: Path, wat: Boolean, dev: Boolean, readChunkSize: Int) extends Options
 
 case class Compile(file: Path, out: Path, debug: Boolean) extends Options

--- a/core/src/swam/binary/InstCodec.scala
+++ b/core/src/swam/binary/InstCodec.scala
@@ -487,11 +487,11 @@ trait InstCodec extends TypeCodec {
         case MemorySize =>
           constant(hex"00")
             .encode(())
-            .map(_ => BitVector.fromByte(OpCode.MemorySize.toByte))
+            .map(BitVector.fromByte(OpCode.MemorySize.toByte) ++ _)
         case MemoryGrow =>
           constant(hex"00")
             .encode(())
-            .map(_ => BitVector.fromByte(OpCode.MemoryGrow.toByte))
+            .map(BitVector.fromByte(OpCode.MemoryGrow.toByte) ++ _)
         case i32.Const(v) =>
           varint32
             .encode(v)

--- a/core/src/swam/binary/WasmCodec.scala
+++ b/core/src/swam/binary/WasmCodec.scala
@@ -110,8 +110,8 @@ object WasmCodec extends InstCodec {
 
   val custom: Codec[(String, BitVector)] =
     variableSizeBytes(varuint32,
-                      (("name" | variableSizeBytes(varuint32, utf8)) ~
-                        ("payload" | scodec.codecs.bits)))
+                      ("name" | variableSizeBytes(varuint32, utf8)) ~
+                        ("payload" | scodec.codecs.bits))
 
   val section =
     discriminated[Section]

--- a/core/src/swam/binary/varint.scala
+++ b/core/src/swam/binary/varint.scala
@@ -46,7 +46,7 @@ private class Varuint(bits: Int) extends Codec[Int] {
     if (n <= 0) {
       Attempt.failure(Err("integer representation too long"))
     } else if (buffer.isEmpty) {
-      Attempt.failure(Err("unexpected end of input"))
+      Attempt.failure(Err.insufficientBits(8, 0))
     } else {
       val byte = buffer.head
       if (n >= 7 || (byte & 0x7f) < (1 << n)) {
@@ -95,8 +95,8 @@ private class Varint(bits: Int) extends Codec[Long] {
 
   private val bitsL = bits.toLong
 
-  val MaxValue = (1 << (bits - 1)) - 1
-  val MinValue = -(1 << (bits - 1))
+  val MaxValue = if (bits == 64) Long.MaxValue else (1L << (bits - 1)) - 1
+  val MinValue = if (bits == 64) Long.MinValue else -(1L << (bits - 1))
 
   private def description = s"$bits-bit signed leb128 integer"
 
@@ -110,7 +110,7 @@ private class Varint(bits: Int) extends Codec[Long] {
     if (n <= 0) {
       Attempt.failure(Err("integer representation too long"))
     } else if (buffer.isEmpty) {
-      Attempt.failure(Err("unexpected end of input"))
+      Attempt.failure(Err.insufficientBits(8, 0))
     } else {
       val byte = buffer.head
       val mask = (-1 << (n - 1)) & 0x7f


### PR DESCRIPTION
This is a partial fix, until scodec/scodec-stream#58 is fixed, but fixes a similar issue in our codebase. In case the scodec bug is hit again, also provides a `--read-chunk-size` option to change buffer size and work around the problem.

Closes #91 